### PR TITLE
Use gaze instead of hound, as it does work with NFS

### DIFF
--- a/md-renderer/index.js
+++ b/md-renderer/index.js
@@ -1,7 +1,7 @@
 var app = require('express')();
 var http = require('http').Server(app);
 var io = require('socket.io')(http);
-var hound = require('hound');
+var gaze = require('gaze');
 var fs = require('fs');
 var needle = require('needle');
 
@@ -27,10 +27,10 @@ if (!fs.lstatSync(filename).isFile()) {
 }
 
 //Setup a watcher for the passed file
-var watcher = hound.watch(filename);
+var watcher = new gaze.Gaze(filename);
 
 //Emit an updating event on change
-watcher.on('change', function(file, stats) {
+watcher.on('all', function(event, file) {
 	update(file);
 	io.emit('updating', file);
 });

--- a/md-renderer/package.json
+++ b/md-renderer/package.json
@@ -14,7 +14,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"express": "^4.13.3",
-		"hound": "^1.0.4",
+		"gaze": "^0.5.2",
 		"needle": "^0.10.0",
 		"socket.io": "^1.3.7"
 	}


### PR DESCRIPTION
Fix the issue of this not working on NFS shares by using another file watching library.
